### PR TITLE
add dot "." because of an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ cd BetterCrewLink-server
 
 2. Run the Docker build command:
 ```sh
-docker build -t ohmyguus/bettercrewlink-server:build
+docker build -t ohmyguus/bettercrewlink-server:build .
 ```
 
 ## Manual Installation


### PR DESCRIPTION
Without the "dot" docker throw ""docker build" requires exactly 1 argument." like it won't find dockerfile.